### PR TITLE
Fix version 2.0 installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         name="shoop-checkoutfi",
         version="0.2",
         description="Shoop Checkout.fi Integration",
-        packages=["shoop_checkoutfi"],
+        packages=setuptools.find_packages(),
         include_package_data=True,
         install_requires=["shoop>=3.0.0.post0.dev233,<5.0"],
         entry_points={"shoop.addon": "shoop_checkoutfi=shoop_checkoutfi"}


### PR DESCRIPTION
This should enable migrations when installing with pip install

Refs SHOOP-2478
