### PR TITLE
Update module "__version__" automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docs/_build/
 target/
 
 .idea
+_version.py

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import os
+
 import setuptools
 
 try:
@@ -6,10 +8,18 @@ except ImportError:
     shoop_setup_utils = None
 
 
+VERSION = '0.3.1'
+
+TOPDIR = os.path.abspath(os.path.dirname(__file__))
+VERSION_FILE = os.path.join(TOPDIR, 'shoop_checkoutfi', '_version.py')
+
 if __name__ == '__main__':
+    if shoop_setup_utils:
+        shoop_setup_utils.write_version_to_file(VERSION, VERSION_FILE)
+
     setuptools.setup(
         name="shoop-checkoutfi",
-        version="0.3.1",
+        version=VERSION,
         description="Shoop Checkout.fi Integration",
         packages=setuptools.find_packages(),
         include_package_data=True,

--- a/shoop_checkoutfi/__init__.py
+++ b/shoop_checkoutfi/__init__.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = 'dev'
 
-__version__ = "0.2"
 default_app_config = "shoop_checkoutfi.apps.CheckoutFiConfig"


### PR DESCRIPTION
While I was doing SHOOP-2664 (see PR #4) noticed that the version in
`shoop_checkoutfi.__version__` is outdated.  Make it update
automatically by using the `write_version_to_file` function of
`shoop_setup_utils`.
