### PR TITLE
Improve Finnish translations (SHOOP-2664)

### DIFF
--- a/shoop_checkoutfi/locale/fi/LC_MESSAGES/django.po
+++ b/shoop_checkoutfi/locale/fi/LC_MESSAGES/django.po
@@ -22,10 +22,10 @@ msgid "Checkout.fi Payments Addon"
 msgstr "Checkout.fi-maksulisäosa"
 
 msgid "Merchant ID"
-msgstr "Kauppiaan tunnus"
+msgstr "Myyjän tunniste"
 
 msgid "Merchant Secret"
-msgstr "Kauppiaan salaisuus"
+msgstr "Myyjän turva-avain"
 
 msgid "Checkout.fi payment processor"
 msgstr "Checkout.fi-maksukäsittelijä"


### PR DESCRIPTION
Improve translation of Merchant ID and secret to be more in line with
the terms used in API documentation written in Finnish:

http://www.checkout.fi/wp-content/uploads/2015/04/CTD-Tekninenrajapintakuvaus-210415-1146-170.pdf
